### PR TITLE
Add BGZF input, FASTA file lists, and named-sequence access

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,7 @@ set(SOURCE_FILES main.cpp
         lib/utils.cpp
         lib/cdt_common.cpp
         lib/input_reader.cpp
+        lib/fasta_reader.cpp
 )
 
 #using malloc_count for monitoring memory usage during debug mode

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,7 @@ set(SOURCE_FILES main.cpp
         external/xxHash-dev/xxhash.c
         lib/utils.cpp
         lib/cdt_common.cpp
+        lib/input_reader.cpp
 )
 
 #using malloc_count for monitoring memory usage during debug mode
@@ -44,4 +45,36 @@ if(UNIX AND NOT APPLE)
         target_link_libraries(lcg LINK_PUBLIC stdc++fs)
 endif()
 
+# Find htslib via pkg-config or use HTSLIB_ROOT hint
+find_package(PkgConfig QUIET)
+if(PkgConfig_FOUND)
+    pkg_check_modules(HTSLIB QUIET htslib)
+endif()
+
+if(NOT HTSLIB_FOUND)
+    # Allow user to specify HTSLIB_ROOT, or fall back to $HOME/htslib-local
+    if(NOT DEFINED HTSLIB_ROOT)
+        set(HTSLIB_ROOT "$ENV{HOME}/htslib-local")
+    endif()
+    if(EXISTS "${HTSLIB_ROOT}/include/htslib/bgzf.h")
+        set(HTSLIB_INCLUDE_DIRS "${HTSLIB_ROOT}/include")
+        set(HTSLIB_LIBRARY_DIRS "${HTSLIB_ROOT}/lib")
+        find_library(HTSLIB_LIB hts PATHS "${HTSLIB_ROOT}/lib" NO_DEFAULT_PATH)
+        if(NOT HTSLIB_LIB)
+            message(FATAL_ERROR "htslib library not found in ${HTSLIB_ROOT}/lib")
+        endif()
+        set(HTSLIB_LIBRARIES "${HTSLIB_LIB}")
+        set(HTSLIB_FOUND TRUE)
+    else()
+        message(FATAL_ERROR "htslib not found. Install libhts-dev or set HTSLIB_ROOT.")
+    endif()
+endif()
+
 target_include_directories(lcg PUBLIC include external/xxHash-dev external/malloc_count)
+if(HTSLIB_INCLUDE_DIRS)
+    target_include_directories(lcg PUBLIC ${HTSLIB_INCLUDE_DIRS})
+endif()
+if(HTSLIB_LIBRARY_DIRS)
+    target_link_directories(lcg PUBLIC ${HTSLIB_LIBRARY_DIRS})
+endif()
+target_link_libraries(lcg LINK_PUBLIC ${HTSLIB_LIBRARIES} z)

--- a/include/build_gram/fasta_reader.h
+++ b/include/build_gram/fasta_reader.h
@@ -1,0 +1,61 @@
+//
+// FASTA file list reader for pangenome-scale workflows
+//
+
+#ifndef LCG_FASTA_READER_H
+#define LCG_FASTA_READER_H
+
+#include "input_reader.h"
+#include <vector>
+#include <string>
+#include <memory>
+
+// Parse a file list: one FASTA path per line, # comments, blank lines skipped.
+std::vector<std::string> parse_fasta_file_list(const std::string& list_path);
+
+// fasta_reader streams unwrapped sequence data from a list of FASTA files,
+// emitting sequences separated by '\n'. Implements the input_reader interface
+// so the downstream chunked parser sees the same byte format as plain text.
+//
+// Pass 1 (constructor): scans all files to collect sequence names and compute
+// total uncompressed data size.
+// Pass 2 (read_data): re-opens files sequentially, skips '>' header lines,
+// strips internal line wrapping, emits '\n' after each complete sequence.
+class fasta_reader : public input_reader {
+public:
+    explicit fasta_reader(std::vector<std::string> file_paths);
+    ~fasta_reader() override = default;
+
+    ssize_t read_data(void* buf, size_t len) override;
+    size_t uncompressed_size() const override;
+
+    void advise_sequential() override;
+    void advise_dontneed(off_t offset, off_t len) override;
+    void advise_dontneed_all() override;
+
+    const std::vector<std::string>& sequence_names() const { return seq_names_; }
+
+private:
+    std::vector<std::string> file_paths_;
+    std::vector<std::string> seq_names_;
+    size_t total_data_bytes_ = 0;
+
+    // read_data state
+    size_t current_file_idx_ = 0;
+    std::unique_ptr<input_reader> current_reader_;
+    bool in_header_ = false;
+    bool need_separator_ = false; // emit '\n' before next sequence data
+    bool first_seq_in_stream_ = true; // first sequence overall, no leading '\n'
+    bool at_eof_ = false;
+
+    // internal raw buffer for reading from current_reader_
+    static constexpr size_t RAW_BUF_SIZE = 8 * 1024 * 1024; // 8MB
+    std::vector<uint8_t> raw_buf_;
+    size_t raw_pos_ = 0;
+    size_t raw_end_ = 0;
+
+    bool open_next_file();
+    bool fill_raw_buf();
+};
+
+#endif //LCG_FASTA_READER_H

--- a/include/build_gram/input_reader.h
+++ b/include/build_gram/input_reader.h
@@ -1,0 +1,74 @@
+//
+// BGZF-aware input reader abstraction for LCG
+//
+
+#ifndef LCG_INPUT_READER_H
+#define LCG_INPUT_READER_H
+
+#include <cstdint>
+#include <cstddef>
+#include <string>
+#include <memory>
+#include <sys/types.h>
+
+class input_reader {
+public:
+    virtual ~input_reader() = default;
+
+    // Read up to len bytes into buf. Returns number of bytes read (0 at EOF).
+    virtual ssize_t read_data(void* buf, size_t len) = 0;
+
+    // Return the uncompressed file size.
+    virtual size_t uncompressed_size() const = 0;
+
+    // Hint to OS for sequential access (no-op for BGZF).
+    virtual void advise_sequential() = 0;
+
+    // Hint to OS to drop pages from cache (no-op for BGZF).
+    virtual void advise_dontneed(off_t offset, off_t len) = 0;
+
+    // Drop all pages from cache (no-op for BGZF).
+    virtual void advise_dontneed_all() = 0;
+};
+
+class plain_reader : public input_reader {
+    int fd_;
+    size_t file_size_;
+public:
+    explicit plain_reader(const std::string& path);
+    ~plain_reader() override;
+
+    ssize_t read_data(void* buf, size_t len) override;
+    size_t uncompressed_size() const override;
+    void advise_sequential() override;
+    void advise_dontneed(off_t offset, off_t len) override;
+    void advise_dontneed_all() override;
+};
+
+class bgzf_reader : public input_reader {
+    void* bgzf_handle_; // BGZF* -- opaque to avoid exposing htslib headers
+    size_t uncomp_size_;
+public:
+    explicit bgzf_reader(const std::string& path);
+    ~bgzf_reader() override;
+
+    ssize_t read_data(void* buf, size_t len) override;
+    size_t uncompressed_size() const override;
+    void advise_sequential() override;
+    void advise_dontneed(off_t offset, off_t len) override;
+    void advise_dontneed_all() override;
+};
+
+// Detect whether a file is BGZF-compressed by checking magic bytes.
+bool is_bgzf_file(const std::string& path);
+
+// Compute uncompressed size of a BGZF file by scanning block headers.
+size_t compute_bgzf_uncompressed_size(const std::string& path);
+
+// Return uncompressed file size regardless of format (plain or BGZF).
+size_t input_file_size(const std::string& path);
+
+// Factory: auto-detect format and return the appropriate reader.
+std::unique_ptr<input_reader> make_input_reader(const std::string& path);
+
+#endif //LCG_INPUT_READER_H

--- a/include/build_gram/lc_parsing.h
+++ b/include/build_gram/lc_parsing.h
@@ -78,6 +78,20 @@ struct parsing_state {
         rem_bytes = (off_t)f_size;
     }
 
+    // Constructor accepting an externally-constructed reader (e.g. fasta_reader)
+    parsing_state(std::unique_ptr<input_reader> ext_reader, size_t data_size, uint8_t s_sym,
+                  size_t c_size, size_t _n_threads, off_t p_cache_lim, float _max_frac):
+                                                                          chunk_size(c_size),
+                                                                          sep_sym(s_sym),
+                                                                          reader(std::move(ext_reader)),
+                                                                          n_threads(_n_threads),
+                                                                          page_cache_limit(p_cache_lim),
+                                                                          max_frac(_max_frac){
+        f_size = data_size;
+        reader->advise_sequential();
+        rem_bytes = (off_t)f_size;
+    }
+
     ~parsing_state(){
         if (reader) {
             reader->advise_dontneed_all();
@@ -730,6 +744,74 @@ void build_lc_gram(std::string& i_file, plain_gram& sink_gram, size_t n_threads,
 #endif
 
 }
+void build_lc_gram_from_reader(std::unique_ptr<input_reader> ext_reader, size_t data_size,
+                               plain_gram& sink_gram, size_t n_threads, off_t chunk_size, float i_frac) {
+
+    auto f_size = (off_t)data_size;
+
+    float i_fracs[4] = {0.1, 0.025, 0.015, 0.006};
+
+    chunk_size = chunk_size==0 ? off_t(ceil(0.005 * double(f_size))) : (off_t)chunk_size;
+    chunk_size = std::min<off_t>(chunk_size, 1024*1024*200);
+
+    size_t tot_chunks = INT_CEIL(f_size, chunk_size);
+    n_threads = std::min(n_threads, tot_chunks);
+
+    size_t n_chunks = n_threads+1;
+    n_chunks = std::min<unsigned long>(n_chunks, tot_chunks);
+
+    if(i_frac==0){
+        if(f_size<=COL_THRESHOLD_1){
+            i_frac = i_fracs[0];
+        } else if(f_size<=COL_THRESHOLD_2){
+            i_frac = i_fracs[1];
+        } else if(f_size<=COL_THRESHOLD_3){
+            i_frac = i_fracs[2];
+        } else{
+            i_frac = i_fracs[3];
+        }
+        i_frac *=float(n_chunks);
+    }
+
+    off_t page_cache_limit = 1024*1024*1024;
+
+    std::cout<<"  Settings"<<std::endl;
+    std::cout<<"    Parsing threads           : "<<n_threads<<std::endl;
+    std::cout<<"    Active text chunks in RAM : "<<n_chunks<<std::endl;
+    std::cout<<"    Size of each chunk        : "<<report_space(chunk_size)<<std::endl;
+    std::cout<<"    Chunks' approx. mem usage : "<<report_space(off_t(((chunk_size*115)/100)*n_chunks))<<"\n"<<std::endl;
+
+    parsing_state par_state(std::move(ext_reader), data_size, sink_gram.sep_sym(), chunk_size, n_threads, page_cache_limit, i_frac);
+
+    std::vector<text_chunk> chunks;
+    chunks.reserve(n_chunks);
+    for(size_t i=0;i<n_chunks;i++){
+        chunks.emplace_back(sink_gram);
+    }
+
+    fill_chunk_grammars<false>(chunks, par_state);
+    collapse_grams(sink_gram, chunks);
+    sink_gram.update_fps();
+    par_state.sink_gram_mem_usage=sink_gram.eff_mem_usage();
+    REPORT_GRAM_SIZE
+
+    while(par_state.rem_bytes>0){
+        fill_chunk_grammars<true>(chunks, par_state);
+        collapse_grams(sink_gram, chunks);
+        sink_gram.update_fps();
+        par_state.sink_gram_mem_usage=sink_gram.eff_mem_usage();
+        REPORT_GRAM_SIZE
+    }
+    std::cout<<" "<<std::endl;
+    sink_gram.reorder_strings();
+
+    sink_gram.clear_fps();
+
+#ifdef DEBUG_MODE
+    sink_gram.print_stats();
+#endif
+}
+
 /*struct inv_perm_elm{
     uint32_t orig_mt;
     uint64_t fp;

--- a/include/build_gram/lc_parsing.h
+++ b/include/build_gram/lc_parsing.h
@@ -52,7 +52,8 @@
 struct parsing_state {
     size_t chunk_size;
     uint8_t sep_sym;
-    int fd_r;
+    std::unique_ptr<input_reader> reader;
+    std::vector<uint8_t> overflow;
     size_t f_size=0;
     size_t n_threads=1;
     off_t rem_bytes=0;
@@ -71,25 +72,24 @@ struct parsing_state {
                                                                           n_threads(_n_threads),
                                                                           page_cache_limit(p_cache_lim),
                                                                           max_frac(_max_frac){
-        fd_r = open(i_file.c_str(), O_RDONLY);
-        f_size = file_size(i_file);
-#ifdef __linux__
-        posix_fadvise(fd_r, 0, f_size, POSIX_FADV_SEQUENTIAL);
-#endif
+        reader = make_input_reader(i_file);
+        f_size = reader->uncompressed_size();
+        reader->advise_sequential();
         rem_bytes = (off_t)f_size;
     }
 
     ~parsing_state(){
-#ifdef __linux__
-        posix_fadvise(fd_r, 0, f_size, POSIX_FADV_DONTNEED);
-#endif
-        close(fd_r);
+        if (reader) {
+            reader->advise_dontneed_all();
+        }
     }
 
     void flush_page_cache(){
 #ifdef __linux__
         std::cout<<"removing from page cache "<<r_page_cache_bytes<<" "<<read_bytes<<std::endl;
-        posix_fadvise(fd_r, read_bytes-r_page_cache_bytes, r_page_cache_bytes, POSIX_FADV_DONTNEED);
+        if (reader) {
+            reader->advise_dontneed(read_bytes-r_page_cache_bytes, r_page_cache_bytes);
+        }
         r_page_cache_bytes=0;
 #endif
     }
@@ -561,7 +561,7 @@ void fill_chunk_grammars(std::vector<text_chunk>& text_chunks, parsing_state& p_
         text_chunks[buff_id].increase_capacity((tmp_ck_size*115)/100);
         text_chunks[buff_id].id = p_state.chunk_id++;
 
-        read_chunk_from_file(p_state.fd_r, p_state.rem_bytes, p_state.read_bytes, text_chunks[buff_id]);
+        read_chunk_from_reader(*p_state.reader, p_state.rem_bytes, p_state.read_bytes, text_chunks[buff_id], p_state.overflow);
         buffers_to_process.push(buff_id);
 
 #ifdef __linux__
@@ -600,7 +600,7 @@ void fill_chunk_grammars(std::vector<text_chunk>& text_chunks, parsing_state& p_
 
         text_chunks[buff_id].text_bytes = tmp_ck_size;
         text_chunks[buff_id].id = p_state.chunk_id++;
-        read_chunk_from_file(p_state.fd_r, p_state.rem_bytes, p_state.read_bytes, text_chunks[buff_id]);
+        read_chunk_from_reader(*p_state.reader, p_state.rem_bytes, p_state.read_bytes, text_chunks[buff_id], p_state.overflow);
         buffers_to_process.push(buff_id);
 
 #ifdef __linux__

--- a/include/build_gram/text_handler.h
+++ b/include/build_gram/text_handler.h
@@ -6,7 +6,9 @@
 #define LCG_TEXT_HANDLER_H
 
 #include "plain_gram.h"
+#include "input_reader.h"
 #include <unistd.h>
+#include <vector>
 
 struct text_chunk {
 
@@ -152,4 +154,83 @@ void read_chunk_from_file(int fd, off_t& rem_text_bytes, off_t& read_text_bytes,
 
     read_text_bytes = lseek(fd, offset*-1, SEEK_CUR);
 }
+
+// Overflow-buffered variant that works with both plain and BGZF readers.
+// Instead of seeking backward, excess bytes after the last separator are
+// stored in `overflow` and prepended to the next chunk.
+void read_chunk_from_reader(input_reader& reader, off_t& rem_text_bytes,
+                            off_t& read_text_bytes, text_chunk& chunk,
+                            std::vector<uint8_t>& overflow) {
+
+    off_t chunk_bytes = chunk.text_bytes < rem_text_bytes ? chunk.text_bytes : rem_text_bytes;
+    chunk.text_bytes = chunk_bytes;
+
+    off_t acc_bytes = 0;
+    off_t fd_buff_bytes = 8388608; // 8MB buffer
+
+    uint8_t* data = chunk.text;
+    chunk.n_bytes_before = read_text_bytes;
+    off_t limit = 0;
+    off_t i = 0;
+
+    // Prepend overflow from previous chunk
+    off_t ovf_bytes = (off_t)overflow.size();
+    if (ovf_bytes > 0) {
+        // Ensure capacity for overflow + requested chunk_bytes
+        chunk.increase_capacity(ovf_bytes + chunk_bytes);
+        memcpy(chunk.text, overflow.data(), ovf_bytes);
+        data = chunk.text + ovf_bytes;
+        acc_bytes = ovf_bytes;
+        chunk_bytes -= std::min(chunk_bytes, ovf_bytes);
+        chunk.text_bytes = ovf_bytes + chunk_bytes;
+        overflow.clear();
+    }
+
+    while (true) {
+        // Read the requested chunk_bytes from the reader
+        off_t remaining = chunk_bytes;
+        while (remaining > 0) {
+            off_t to_read = fd_buff_bytes < remaining ? fd_buff_bytes : remaining;
+            ssize_t read_bytes = reader.read_data(data, to_read);
+            if (read_bytes <= 0) break;
+            data += read_bytes;
+            remaining -= read_bytes;
+            acc_bytes += read_bytes;
+        }
+
+        // Adjust text_bytes to actual bytes read (in case EOF cut short)
+        chunk.text_bytes = acc_bytes;
+        if (acc_bytes == 0) break;
+
+        // Find rightmost separator
+        i = chunk.text_bytes - 1;
+        while (i > limit && chunk.text[i] != chunk.sep_sym) {
+            i--;
+        }
+        if (i > limit) break;
+
+        // No separator found -- grow the chunk by 25% and read more
+        off_t tmp_ck_size = INT_CEIL(((chunk.text_bytes * 125) / 100), sizeof(text_chunk::size_type)) * sizeof(text_chunk::size_type);
+        tmp_ck_size = std::min(tmp_ck_size, ovf_bytes + rem_text_bytes);
+        chunk_bytes = tmp_ck_size - chunk.text_bytes;
+        chunk.text_bytes = tmp_ck_size;
+
+        chunk.increase_capacity(chunk.text_bytes);
+        data = &chunk.text[chunk.text_bytes - chunk_bytes];
+    }
+
+    off_t eff_bytes = i + 1;
+    chunk.text_bytes = eff_bytes;
+    chunk.e_bytes = eff_bytes;
+
+    // Store excess bytes in overflow buffer instead of seeking backward
+    off_t excess = acc_bytes - eff_bytes;
+    if (excess > 0) {
+        overflow.assign(chunk.text + eff_bytes, chunk.text + eff_bytes + excess);
+    }
+
+    rem_text_bytes -= eff_bytes;
+    read_text_bytes += eff_bytes;
+}
+
 #endif //LCG_TEXT_HANDLER_H

--- a/include/cds/cdt_common.hpp
+++ b/include/cds/cdt_common.hpp
@@ -5,6 +5,7 @@
 #ifndef CDT_COMMON_H
 #define CDT_COMMON_H
 
+#include <cstdint>
 #include <iostream>
 #include <fstream>
 #include "memory_handler.hpp"

--- a/include/grammar.h
+++ b/include/grammar.h
@@ -65,6 +65,7 @@ struct lc_gram_t {
     std::vector<uint8_t> terminals; //set of terminals
     std::vector<size_t> str_boundaries; // start position of every string in the compressed string
     std::vector<size_t> lvl_rules; //number of rules generated in every round of locally-consistent parsing
+    std::vector<std::string> seq_names; // FASTA sequence names (empty for plain text input)
 
     bitstream<size_t> rule_stream;
     int_array<size_t> rl_ptr; //pointer in "rules" to the leftmost symbol of each rule
@@ -104,6 +105,18 @@ struct lc_gram_t {
         written_bytes += serialize_plain_vector(ofs, str_boundaries);
         written_bytes += rl_ptr.serialize(ofs);
         written_bytes += rule_stream.serialize(ofs);
+
+        // seq_names section (backwards compatible: old readers stop at rule_stream)
+        if (!seq_names.empty()) {
+            size_t n_names = seq_names.size();
+            written_bytes += serialize_elm(ofs, n_names);
+            for (const auto& name : seq_names) {
+                size_t name_len = name.size();
+                written_bytes += serialize_elm(ofs, name_len);
+                ofs.write(name.data(), (std::streamsize)name_len);
+                written_bytes += name_len;
+            }
+        }
 
         return written_bytes;
     }
@@ -164,6 +177,7 @@ struct lc_gram_t {
         str_boundaries.swap(other.str_boundaries);
         rl_ptr.swap(other.rl_ptr);
         rule_stream.swap(other.rule_stream);
+        seq_names.swap(other.seq_names);
     }
 
     void load_pointers(std::ifstream &ifs) {
@@ -176,6 +190,19 @@ struct lc_gram_t {
         load_metadata(ifs);
         load_pointers(ifs);
         rule_stream.load(ifs);
+
+        // read seq_names if present (backwards compat: old files have EOF here)
+        if (ifs.peek() != EOF) {
+            size_t n_names = 0;
+            load_elm(ifs, n_names);
+            seq_names.resize(n_names);
+            for (size_t i = 0; i < n_names; i++) {
+                size_t name_len = 0;
+                load_elm(ifs, name_len);
+                seq_names[i].resize(name_len);
+                ifs.read(seq_names[i].data(), (std::streamsize)name_len);
+            }
+        }
     }
 
     [[nodiscard]] inline std::pair<off_t, off_t> nt2bitrange(size_t sym) const {

--- a/include/grammar_algorithms.h
+++ b/include/grammar_algorithms.h
@@ -7,6 +7,7 @@
 
 #include "grammar.h"
 #include "build_gram/lc_parsing.h"
+#include "build_gram/input_reader.h"
 #include "cds/file_streams.hpp"
 #include "cds/ts_string_map.h"
 
@@ -1194,7 +1195,7 @@ template<class gram_type>
 void build_gram(std::string &i_file, std::string& o_file, size_t n_threads, off_t chunk_size,
                 float i_frac, bool skip_simp, bool par_gram, bool check_gram) {
 
-    plain_gram p_gram(40, '\n', file_size(i_file));
+    plain_gram p_gram(40, '\n', input_file_size(i_file));
 
     std::cout<<"Building a locally-consistent grammar"<<std::endl;
     auto start = std::chrono::steady_clock::now();

--- a/include/grammar_algorithms.h
+++ b/include/grammar_algorithms.h
@@ -8,6 +8,7 @@
 #include "grammar.h"
 #include "build_gram/lc_parsing.h"
 #include "build_gram/input_reader.h"
+#include "build_gram/fasta_reader.h"
 #include "cds/file_streams.hpp"
 #include "cds/ts_string_map.h"
 
@@ -1259,6 +1260,68 @@ void build_gram(std::string &i_file, std::string& o_file, size_t n_threads, off_
         check_plain_grammar(final_gram, i_file);
     }
     //
+
+#if DEBUG_MODE
+    std::cout<<"Stats for the final grammar:"<<std::endl;
+    final_gram.breakdown(2);
+#endif
+
+    size_t written_bytes = store_to_file(o_file, final_gram);
+    std::cout<<"The resulting grammar uses "+ report_space((off_t)written_bytes)+" and was stored in "<<o_file<<std::endl;
+}
+
+// Overload for reader-based input (e.g. FASTA file list)
+template<class gram_type>
+void build_gram(std::unique_ptr<input_reader> reader, size_t data_size,
+                std::vector<std::string> seq_names, std::string& o_file,
+                size_t n_threads, off_t chunk_size, float i_frac,
+                bool skip_simp, bool par_gram) {
+
+    plain_gram p_gram(40, '\n', data_size);
+
+    std::cout<<"Building a locally-consistent grammar"<<std::endl;
+    auto start = std::chrono::steady_clock::now();
+    build_lc_gram_from_reader(std::move(reader), data_size, p_gram, n_threads, chunk_size, i_frac);
+    auto end = std::chrono::steady_clock::now();
+
+#ifdef DEBUG_MODE
+    report_time(start, end, 2);
+#endif
+
+    if(par_gram){
+        std::cout<<"The resulting grammar was stored in "<<o_file<<std::endl;
+        return;
+    }
+
+    using tmp_gram_type = lc_gram_t<gram_type::has_cg_rules, gram_type::has_rl_rules, false>;
+    tmp_gram_type compact_gram;
+    complete_and_pack_grammar(p_gram, compact_gram);
+
+    if(gram_type::has_rl_rules){
+        std::cout<<"Run-length compressing the grammar"<<std::endl;
+        run_length_compress(compact_gram);
+    }
+
+    if(!skip_simp){
+        std::cout<<"Simplifying the grammar"<<std::endl;
+        simplify_grammar(compact_gram);
+    }
+
+    if(gram_type::has_rand_access){
+        std::cout<<"Adding random access support"<<std::endl;
+        start = std::chrono::steady_clock::now();
+        add_random_access_support(compact_gram);
+        end = std::chrono::steady_clock::now();
+#ifdef DEBUG_MODE
+        report_time(start, end, 2);
+#endif
+    }
+
+    gram_type final_gram;
+    final_gram.swap(compact_gram);
+
+    // Transfer sequence names to the grammar
+    final_gram.seq_names = std::move(seq_names);
 
 #if DEBUG_MODE
     std::cout<<"Stats for the final grammar:"<<std::endl;

--- a/lib/fasta_reader.cpp
+++ b/lib/fasta_reader.cpp
@@ -1,0 +1,347 @@
+//
+// FASTA file list reader implementation
+//
+
+#include "build_gram/fasta_reader.h"
+
+#include <fstream>
+#include <iostream>
+#include <stdexcept>
+#include <unordered_set>
+#include <algorithm>
+#include <cstring>
+
+// --- parse_fasta_file_list ---
+
+std::vector<std::string> parse_fasta_file_list(const std::string& list_path) {
+    std::ifstream ifs(list_path);
+    if (!ifs.is_open()) {
+        throw std::runtime_error("Cannot open file list: " + list_path);
+    }
+
+    std::vector<std::string> paths;
+    std::string line;
+    while (std::getline(ifs, line)) {
+        // strip trailing \r
+        if (!line.empty() && line.back() == '\r') {
+            line.pop_back();
+        }
+        // strip leading/trailing whitespace
+        size_t start = line.find_first_not_of(" \t");
+        if (start == std::string::npos) continue; // blank line
+        size_t end = line.find_last_not_of(" \t");
+        line = line.substr(start, end - start + 1);
+        // skip comments
+        if (line.empty() || line[0] == '#') continue;
+        paths.push_back(line);
+    }
+    return paths;
+}
+
+// --- fasta_reader Pass 1: scan ---
+
+// Helper: scan a single FASTA file to collect sequence names and data bytes.
+// Uses the input_reader interface so it handles both plain and BGZF files.
+static void scan_fasta_file(const std::string& path,
+                            std::vector<std::string>& seq_names,
+                            std::unordered_set<std::string>& seen_names,
+                            size_t& total_data_bytes) {
+    auto reader = make_input_reader(path);
+
+    static constexpr size_t SCAN_BUF_SIZE = 4 * 1024 * 1024;
+    std::vector<uint8_t> buf(SCAN_BUF_SIZE);
+    size_t buf_pos = 0, buf_end = 0;
+
+    bool in_header = false;
+    bool first_line = true;
+    bool seen_any_header = false;
+    std::string current_header;
+    size_t current_seq_bytes = 0;
+
+    auto fill = [&]() -> bool {
+        ssize_t n = reader->read_data(buf.data(), SCAN_BUF_SIZE);
+        if (n <= 0) return false;
+        buf_pos = 0;
+        buf_end = (size_t)n;
+        return true;
+    };
+
+    // Process byte by byte through the buffer (fast inner loop)
+    while (true) {
+        if (buf_pos >= buf_end) {
+            if (!fill()) break;
+        }
+
+        // Find end of current line
+        size_t line_start = buf_pos;
+        while (buf_pos < buf_end && buf[buf_pos] != '\n') {
+            buf_pos++;
+        }
+
+        if (buf_pos < buf_end) {
+            // Found '\n' — we have a complete line segment
+            size_t line_end = buf_pos;
+            buf_pos++; // skip '\n'
+
+            // strip \r
+            if (line_end > line_start && buf[line_end - 1] == '\r') {
+                line_end--;
+            }
+
+            if (in_header) {
+                // Continuation of a header line that was split across buffers
+                // (this shouldn't happen often since headers are short)
+                for (size_t i = line_start; i < line_end; i++) {
+                    current_header.push_back((char)buf[i]);
+                }
+                in_header = false;
+
+                // Parse the name from the header
+                std::string name;
+                size_t name_start = 0;
+                // skip leading whitespace after '>'
+                while (name_start < current_header.size() &&
+                       (current_header[name_start] == ' ' || current_header[name_start] == '\t')) {
+                    name_start++;
+                }
+                size_t name_end = name_start;
+                while (name_end < current_header.size() &&
+                       current_header[name_end] != ' ' && current_header[name_end] != '\t') {
+                    name_end++;
+                }
+                name = current_header.substr(name_start, name_end - name_start);
+
+                if (name.empty()) {
+                    throw std::runtime_error("Empty sequence name in FASTA header in " + path);
+                }
+                if (seen_names.count(name)) {
+                    throw std::runtime_error("Duplicate sequence name '" + name + "' in " + path);
+                }
+                seen_names.insert(name);
+                seq_names.push_back(name);
+                seen_any_header = true;
+                current_header.clear();
+                continue;
+            }
+
+            // Start of a new line
+            if (line_start < line_end && buf[line_start] == '>') {
+                // This is a header line
+                if (!first_line && seen_any_header) {
+                    // End of previous sequence
+                    if (current_seq_bytes == 0) {
+                        std::cerr << "Warning: empty sequence '" << seq_names.back() << "' in " << path << std::endl;
+                    }
+                    total_data_bytes += current_seq_bytes + 1; // +1 for '\n' separator
+                    current_seq_bytes = 0;
+                }
+                first_line = false;
+
+                // Parse header: extract first whitespace-delimited token after '>'
+                current_header.clear();
+                for (size_t i = line_start + 1; i < line_end; i++) {
+                    current_header.push_back((char)buf[i]);
+                }
+
+                std::string name;
+                size_t name_start = 0;
+                while (name_start < current_header.size() &&
+                       (current_header[name_start] == ' ' || current_header[name_start] == '\t')) {
+                    name_start++;
+                }
+                size_t name_end = name_start;
+                while (name_end < current_header.size() &&
+                       current_header[name_end] != ' ' && current_header[name_end] != '\t') {
+                    name_end++;
+                }
+                name = current_header.substr(name_start, name_end - name_start);
+
+                if (name.empty()) {
+                    throw std::runtime_error("Empty sequence name in FASTA header in " + path);
+                }
+                if (seen_names.count(name)) {
+                    throw std::runtime_error("Duplicate sequence name '" + name + "' in " + path);
+                }
+                seen_names.insert(name);
+                seq_names.push_back(name);
+                seen_any_header = true;
+                current_header.clear();
+            } else {
+                // Sequence data line
+                if (!seen_any_header && line_start < line_end) {
+                    throw std::runtime_error("File does not appear to be FASTA (data before first header): " + path);
+                }
+                current_seq_bytes += (line_end - line_start);
+            }
+            first_line = false;
+        } else {
+            // Reached end of buffer without finding '\n' — partial line
+            if (line_start < buf_end) {
+                if (!in_header && buf[line_start] == '>') {
+                    // Start of a header that's split across buffers
+                    if (!first_line && seen_any_header) {
+                        if (current_seq_bytes == 0) {
+                            std::cerr << "Warning: empty sequence '" << seq_names.back() << "' in " << path << std::endl;
+                        }
+                        total_data_bytes += current_seq_bytes + 1;
+                        current_seq_bytes = 0;
+                    }
+                    first_line = false;
+                    in_header = true;
+                    current_header.clear();
+                    for (size_t i = line_start + 1; i < buf_end; i++) {
+                        current_header.push_back((char)buf[i]);
+                    }
+                } else if (in_header) {
+                    for (size_t i = line_start; i < buf_end; i++) {
+                        current_header.push_back((char)buf[i]);
+                    }
+                } else {
+                    // Partial sequence data line
+                    if (!seen_any_header) {
+                        throw std::runtime_error("File does not appear to be FASTA (data before first header): " + path);
+                    }
+                    current_seq_bytes += (buf_end - line_start);
+                }
+            }
+            // Need more data
+        }
+    }
+
+    // Handle last sequence
+    if (seen_any_header) {
+        if (current_seq_bytes == 0) {
+            std::cerr << "Warning: empty sequence '" << seq_names.back() << "' in " << path << std::endl;
+        }
+        total_data_bytes += current_seq_bytes + 1; // +1 for '\n' separator
+    }
+
+    if (!seen_any_header) {
+        throw std::runtime_error("File does not appear to be FASTA (no headers found): " + path);
+    }
+}
+
+fasta_reader::fasta_reader(std::vector<std::string> file_paths)
+    : file_paths_(std::move(file_paths)) {
+
+    if (file_paths_.empty()) {
+        throw std::runtime_error("fasta_reader: empty file list");
+    }
+
+    // Pass 1: scan all files
+    std::unordered_set<std::string> seen_names;
+    for (const auto& path : file_paths_) {
+        scan_fasta_file(path, seq_names_, seen_names, total_data_bytes_);
+    }
+
+    // Allocate raw buffer for Pass 2
+    raw_buf_.resize(RAW_BUF_SIZE);
+}
+
+// --- fasta_reader Pass 2: read_data ---
+
+size_t fasta_reader::uncompressed_size() const {
+    return total_data_bytes_;
+}
+
+void fasta_reader::advise_sequential() {}
+void fasta_reader::advise_dontneed(off_t, off_t) {}
+void fasta_reader::advise_dontneed_all() {}
+
+bool fasta_reader::open_next_file() {
+    if (current_file_idx_ >= file_paths_.size()) {
+        at_eof_ = true;
+        return false;
+    }
+    current_reader_ = make_input_reader(file_paths_[current_file_idx_++]);
+    raw_pos_ = 0;
+    raw_end_ = 0;
+    in_header_ = false;
+    return true;
+}
+
+bool fasta_reader::fill_raw_buf() {
+    if (!current_reader_) return false;
+    ssize_t n = current_reader_->read_data(raw_buf_.data(), RAW_BUF_SIZE);
+    if (n <= 0) return false;
+    raw_pos_ = 0;
+    raw_end_ = (size_t)n;
+    return true;
+}
+
+ssize_t fasta_reader::read_data(void* buf, size_t len) {
+    if (at_eof_ || len == 0) return 0;
+
+    uint8_t* out = static_cast<uint8_t*>(buf);
+    size_t written = 0;
+
+    while (written < len) {
+        // Ensure we have a reader open
+        if (!current_reader_) {
+            if (!open_next_file()) break;
+        }
+
+        // Ensure we have data in raw buffer
+        if (raw_pos_ >= raw_end_) {
+            if (!fill_raw_buf()) {
+                // Current file exhausted. Emit final '\n' for last sequence if needed.
+                // (We'll handle this via need_separator_ on next file open)
+                current_reader_.reset();
+                continue;
+            }
+        }
+
+        // Process raw buffer bytes → output buffer
+        while (written < len && raw_pos_ < raw_end_) {
+            uint8_t ch = raw_buf_[raw_pos_];
+
+            if (in_header_) {
+                // Skip until end of header line
+                if (ch == '\n') {
+                    in_header_ = false;
+                }
+                raw_pos_++;
+                continue;
+            }
+
+            if (ch == '>') {
+                // Start of a new header
+                // If we have a previous sequence, emit separator
+                if (need_separator_) {
+                    out[written++] = '\n';
+                    need_separator_ = false;
+                }
+                in_header_ = true;
+                // After this header, the next sequence data should set need_separator_
+                raw_pos_++;
+                continue;
+            }
+
+            if (ch == '\n' || ch == '\r') {
+                // Skip line wrapping within sequence data
+                raw_pos_++;
+                continue;
+            }
+
+            // Sequence data character
+            // Before first char of a sequence, mark that we'll need a separator later
+            if (!need_separator_ && !first_seq_in_stream_) {
+                // We just finished a header, about to start data
+            }
+            first_seq_in_stream_ = false;
+            need_separator_ = true;
+
+            out[written++] = ch;
+            raw_pos_++;
+        }
+    }
+
+    // If we've exhausted all files, emit final '\n'
+    if (written < len && !current_reader_ && current_file_idx_ >= file_paths_.size() && need_separator_) {
+        out[written++] = '\n';
+        need_separator_ = false;
+        at_eof_ = true;
+    }
+
+    return (ssize_t)written;
+}

--- a/lib/input_reader.cpp
+++ b/lib/input_reader.cpp
@@ -1,0 +1,221 @@
+//
+// BGZF-aware input reader implementation for LCG
+//
+
+#include "build_gram/input_reader.h"
+
+#include <fcntl.h>
+#include <unistd.h>
+#include <cstring>
+#include <fstream>
+#include <stdexcept>
+#include <vector>
+
+#ifdef __linux__
+#include <sys/types.h>
+#endif
+
+#include <htslib/bgzf.h>
+
+// --- plain_reader ---
+
+plain_reader::plain_reader(const std::string& path) {
+    fd_ = open(path.c_str(), O_RDONLY);
+    if (fd_ < 0) {
+        throw std::runtime_error("plain_reader: cannot open " + path);
+    }
+    std::ifstream in(path, std::ifstream::ate | std::ifstream::binary);
+    file_size_ = in.tellg();
+}
+
+plain_reader::~plain_reader() {
+    if (fd_ >= 0) close(fd_);
+}
+
+ssize_t plain_reader::read_data(void* buf, size_t len) {
+    return ::read(fd_, buf, len);
+}
+
+size_t plain_reader::uncompressed_size() const {
+    return file_size_;
+}
+
+void plain_reader::advise_sequential() {
+#ifdef __linux__
+    posix_fadvise(fd_, 0, file_size_, POSIX_FADV_SEQUENTIAL);
+#endif
+}
+
+void plain_reader::advise_dontneed(off_t offset, off_t len) {
+#ifdef __linux__
+    posix_fadvise(fd_, offset, len, POSIX_FADV_DONTNEED);
+#else
+    (void)offset; (void)len;
+#endif
+}
+
+void plain_reader::advise_dontneed_all() {
+#ifdef __linux__
+    posix_fadvise(fd_, 0, file_size_, POSIX_FADV_DONTNEED);
+#endif
+}
+
+// --- bgzf_reader ---
+
+bgzf_reader::bgzf_reader(const std::string& path) {
+    uncomp_size_ = compute_bgzf_uncompressed_size(path);
+    BGZF* fp = bgzf_open(path.c_str(), "r");
+    if (!fp) {
+        throw std::runtime_error("bgzf_reader: cannot open " + path);
+    }
+    bgzf_handle_ = fp;
+}
+
+bgzf_reader::~bgzf_reader() {
+    if (bgzf_handle_) {
+        bgzf_close(static_cast<BGZF*>(bgzf_handle_));
+    }
+}
+
+ssize_t bgzf_reader::read_data(void* buf, size_t len) {
+    ssize_t ret = bgzf_read(static_cast<BGZF*>(bgzf_handle_), buf, len);
+    return ret;
+}
+
+size_t bgzf_reader::uncompressed_size() const {
+    return uncomp_size_;
+}
+
+void bgzf_reader::advise_sequential() {
+    // No meaningful fadvise for BGZF
+}
+
+void bgzf_reader::advise_dontneed(off_t, off_t) {
+    // No meaningful fadvise for BGZF
+}
+
+void bgzf_reader::advise_dontneed_all() {
+    // No meaningful fadvise for BGZF
+}
+
+// --- Detection and sizing utilities ---
+
+bool is_bgzf_file(const std::string& path) {
+    uint8_t buf[18];
+    int fd = open(path.c_str(), O_RDONLY);
+    if (fd < 0) return false;
+
+    ssize_t n = ::read(fd, buf, 18);
+    close(fd);
+
+    if (n < 18) return false;
+
+    // Check gzip magic
+    if (buf[0] != 0x1f || buf[1] != 0x8b) return false;
+    // Check deflate method
+    if (buf[2] != 0x08) return false;
+    // FLG.FEXTRA must be set (bit 2)
+    if (!(buf[3] & 0x04)) return false;
+    // XLEN at offset 10 (little-endian) must be >= 6
+    uint16_t xlen = buf[10] | (buf[11] << 8);
+    if (xlen < 6) return false;
+    // Check BGZF extra field: SI1='B', SI2='C' at offset 12-13
+    if (buf[12] != 'B' || buf[13] != 'C') return false;
+
+    return true;
+}
+
+size_t compute_bgzf_uncompressed_size(const std::string& path) {
+    int fd = open(path.c_str(), O_RDONLY);
+    if (fd < 0) {
+        throw std::runtime_error("compute_bgzf_uncompressed_size: cannot open " + path);
+    }
+
+#ifdef __linux__
+    // Get file size for fadvise
+    off_t fsize = lseek(fd, 0, SEEK_END);
+    lseek(fd, 0, SEEK_SET);
+    posix_fadvise(fd, 0, fsize, POSIX_FADV_SEQUENTIAL);
+#endif
+
+    // Read file in large chunks, parse BGZF block headers from the buffer
+    static constexpr size_t READ_BUF_SIZE = 1024 * 1024; // 1MB
+    std::vector<uint8_t> read_buf(READ_BUF_SIZE);
+    size_t total_uncompressed = 0;
+
+    // Buffered reading state
+    size_t buf_pos = 0;   // current position in read_buf
+    size_t buf_end = 0;   // valid bytes in read_buf
+
+    auto fill_buffer = [&]() -> bool {
+        // Move unconsumed data to front
+        if (buf_pos > 0 && buf_pos < buf_end) {
+            memmove(read_buf.data(), read_buf.data() + buf_pos, buf_end - buf_pos);
+            buf_end -= buf_pos;
+            buf_pos = 0;
+        } else if (buf_pos >= buf_end) {
+            buf_pos = 0;
+            buf_end = 0;
+        }
+        // Read more data
+        ssize_t n = ::read(fd, read_buf.data() + buf_end, READ_BUF_SIZE - buf_end);
+        if (n <= 0) return false;
+        buf_end += n;
+        return true;
+    };
+
+    // Ensure at least `needed` bytes are available starting at buf_pos
+    auto ensure_bytes = [&](size_t needed) -> bool {
+        while ((buf_end - buf_pos) < needed) {
+            if (!fill_buffer()) return false;
+        }
+        return true;
+    };
+
+    while (true) {
+        // Need at least 18 bytes for the BGZF block header
+        if (!ensure_bytes(18)) break;
+
+        uint8_t* hdr = read_buf.data() + buf_pos;
+
+        // Validate gzip magic + BGZF signature
+        if (hdr[0] != 0x1f || hdr[1] != 0x8b || hdr[2] != 0x08) break;
+        if (!(hdr[3] & 0x04)) break;
+
+        // BSIZE is at offset 16-17 in the header (within the BC extra field)
+        // hdr[10..11] = XLEN, hdr[12]='B', hdr[13]='C', hdr[14..15]=SLEN(2), hdr[16..17]=BSIZE
+        uint16_t bsize = hdr[16] | (hdr[17] << 8);
+        size_t block_size = (size_t)bsize + 1; // total block size
+
+        // The ISIZE (uncompressed size of this block) is the last 4 bytes of the block
+        // We need to read up to offset (block_size - 4) from block start to get ISIZE
+        if (!ensure_bytes(block_size)) break;
+
+        uint8_t* block = read_buf.data() + buf_pos;
+        uint32_t isize = (uint32_t)block[block_size - 4]
+                       | ((uint32_t)block[block_size - 3] << 8)
+                       | ((uint32_t)block[block_size - 2] << 16)
+                       | ((uint32_t)block[block_size - 1] << 24);
+
+        total_uncompressed += isize;
+        buf_pos += block_size;
+    }
+
+    close(fd);
+    return total_uncompressed;
+}
+
+size_t input_file_size(const std::string& path) {
+    if (is_bgzf_file(path)) {
+        return compute_bgzf_uncompressed_size(path);
+    }
+    std::ifstream in(path, std::ifstream::ate | std::ifstream::binary);
+    return in.tellg();
+}
+
+std::unique_ptr<input_reader> make_input_reader(const std::string& path) {
+    if (is_bgzf_file(path)) {
+        return std::make_unique<bgzf_reader>(path);
+    }
+    return std::make_unique<plain_reader>(path);
+}

--- a/main.cpp
+++ b/main.cpp
@@ -262,12 +262,16 @@ std::vector<str_coord_type> parse_query_coords(std::vector<std::string>& str_que
     query_coords.reserve(str_queries.size());
 
     for(auto const &coord: str_queries){
-        std::vector<std::string> tmp = split(coord, ':');
-        if(tmp.size()!=2){
+        // Split on the LAST ':' so sequence names containing ':' work
+        auto last_colon = coord.rfind(':');
+        if(last_colon == std::string::npos || last_colon == 0 || last_colon == coord.size()-1){
             std::cout<<"Coordinate error: query \""<<coord<<"\" is ill-formed"<<std::endl;
             exit(1);
         }
-        std::vector<std::string> tmp2 = split(tmp[1], '-');
+        std::string str_part = coord.substr(0, last_colon);
+        std::string range_part = coord.substr(last_colon + 1);
+
+        std::vector<std::string> tmp2 = split(range_part, '-');
         if(tmp2.size()!=2){
             std::cout<<"Coordinate error: query \""<<coord<<"\" is ill-formed"<<std::endl;
             exit(1);
@@ -275,14 +279,14 @@ std::vector<str_coord_type> parse_query_coords(std::vector<std::string>& str_que
 
         // Try numeric parse first; if it fails, look up as sequence name
         try{
-            str = stoi(tmp[0]);
+            str = stoi(str_part);
         } catch (const std::invalid_argument &) {
             // Not a number — try name lookup
-            auto it = name_map.find(tmp[0]);
+            auto it = name_map.find(str_part);
             if (it != name_map.end()) {
                 str = it->second;
             } else {
-                std::cout << "Coordinate error: sequence name \"" << tmp[0]
+                std::cout << "Coordinate error: sequence name \"" << str_part
                           << "\" not found in grammar" << std::endl;
                 if (!seq_names.empty()) {
                     std::cout << "  Available sequences:";
@@ -295,7 +299,7 @@ std::vector<str_coord_type> parse_query_coords(std::vector<std::string>& str_que
                 exit(1);
             }
         } catch (const std::out_of_range &) {
-            std::cout << "Coordinate error: \""<<tmp[0] <<"\" in \""<<coord<<"\" is not a valid string ID\n";
+            std::cout << "Coordinate error: \""<<str_part <<"\" in \""<<coord<<"\" is not a valid string ID\n";
             exit(1);
         }
 

--- a/main.cpp
+++ b/main.cpp
@@ -2,6 +2,8 @@
 #include "merge_grams.h"
 #include "grammar_algorithms.h"
 #include "build_gram/input_reader.h"
+#include "build_gram/fasta_reader.h"
+#include <unordered_map>
 
 struct arguments{
     std::string input_file;
@@ -20,6 +22,7 @@ struct arguments{
     bool check_gram=false;
     size_t seed=0;
 
+    std::string fasta_list;
     std::string p_file;
     std::vector<std::string> grammars_to_merge;
     std::vector<std::string> position_list;
@@ -92,7 +95,8 @@ static void parse_app(CLI::App& app, struct arguments& args){
     CLI::App* comp = app.add_subcommand("cmp", "Compress text");
 
     //compression
-    comp->add_option("TEXT", args.input_file, "Input file in one-string-per-line format")->check(CLI::ExistingFile)->required();
+    comp->add_option("TEXT", args.input_file, "Input file in one-string-per-line format")->check(CLI::ExistingFile);
+    comp->add_option("-l,--fasta-list", args.fasta_list, "File containing list of FASTA file paths (one per line)")->check(CLI::ExistingFile);
     comp->add_option("-o,--output-file", args.output_file, "Output file")->type_name("");
     comp->add_option("-t,--threads", args.n_threads, "Maximum number of parsing threads")->default_val(1);
 
@@ -155,53 +159,102 @@ void comp_int(std::string& input_file, arguments& args) {
     }
 }
 
-void access_int(std::string& input_file, std::vector<str_coord_type>& query_coords, bool has_rl_rules, bool has_cg_rules, bool has_rand_access) {
+// Forward declaration
+std::vector<str_coord_type> parse_query_coords(std::vector<std::string>& str_queries,
+                                               const std::vector<std::string>& seq_names);
+
+void comp_fasta_int(arguments& args) {
+    auto file_paths = parse_fasta_file_list(args.fasta_list);
+    if (file_paths.empty()) {
+        std::cerr << "Error: no files found in " << args.fasta_list << std::endl;
+        exit(1);
+    }
+
+    std::cout << "\nFASTA file list: " << args.fasta_list << " (" << file_paths.size() << " files)" << std::endl;
+
+    auto reader = std::make_unique<fasta_reader>(file_paths);
+    auto seq_names = reader->sequence_names();
+    size_t data_size = reader->uncompressed_size();
+
+    std::cout << "Total sequences: " << seq_names.size() << std::endl;
+    std::cout << "Total data size: " << report_space((off_t)data_size) << std::endl;
+
+    if (args.output_file.empty()) {
+        args.output_file = std::filesystem::path(args.fasta_list).filename();
+    }
+    args.output_file = std::filesystem::path(args.output_file).replace_extension(".lcg");
+
+    // Copy seq_names before moving the reader
+    std::vector<std::string> names_copy = seq_names;
+
+    if (args.skip_rl) {
+        if (args.rand_acc) {
+            build_gram<lc_gram_t<false, false, true>>(std::move(reader), data_size, std::move(names_copy),
+                                                       args.output_file, args.n_threads,
+                                                       args.chunk_size, args.i_frac,
+                                                       args.skip_simp, args.part);
+        } else {
+            build_gram<lc_gram_t<false, false, false>>(std::move(reader), data_size, std::move(names_copy),
+                                                        args.output_file, args.n_threads,
+                                                        args.chunk_size, args.i_frac,
+                                                        args.skip_simp, args.part);
+        }
+    } else {
+        if (args.rand_acc) {
+            build_gram<lc_gram_t<false, true, true>>(std::move(reader), data_size, std::move(names_copy),
+                                                      args.output_file, args.n_threads,
+                                                      args.chunk_size, args.i_frac,
+                                                      args.skip_simp, args.part);
+        } else {
+            build_gram<lc_gram_t<false, true, false>>(std::move(reader), data_size, std::move(names_copy),
+                                                       args.output_file, args.n_threads,
+                                                       args.chunk_size, args.i_frac,
+                                                       args.skip_simp, args.part);
+        }
+    }
+}
+
+template<class gram_t>
+void access_with_gram(std::string& input_file, std::vector<std::string>& str_queries) {
+    gram_t gram;
+    load_from_file(input_file, gram);
+
+    std::vector<str_coord_type> query_coords = parse_query_coords(str_queries, gram.seq_names);
+
+    for(auto const& query : query_coords){
+        std::string dc_output;
+        gram.im_str_rand_access(query.str, query.start, query.end, dc_output);
+        std::cout<<query.str<<":"<<query.start<<"-"<<query.end<<std::endl;
+        std::cout<<dc_output<<std::endl;
+    }
+}
+
+void access_int(std::string& input_file, std::vector<std::string>& str_queries, bool has_rl_rules, bool has_cg_rules, bool has_rand_access) {
     assert(has_rand_access);
     if(has_cg_rules){
         if(has_rl_rules){
-            lc_gram_t<true, true, true> gram;
-            load_from_file(input_file, gram);
-            for(auto const& query : query_coords){
-                std::string dc_output;
-                gram.im_str_rand_access(query.str, query.start, query.end, dc_output);
-                std::cout<<query.start<<":"<<query.start<<"-"<<query.end<<std::endl;
-                std::cout<<dc_output<<std::endl;
-            }
+            access_with_gram<lc_gram_t<true, true, true>>(input_file, str_queries);
         }else{
-            lc_gram_t<true, false, true> gram;
-            load_from_file(input_file, gram);
-            for(auto const& query : query_coords){
-                std::string dc_output;
-                gram.im_str_rand_access(query.str, query.start, query.end, dc_output);
-                std::cout<<query.str<<":"<<query.start<<"-"<<query.end<<std::endl;
-                std::cout<<dc_output<<std::endl;
-            }
+            access_with_gram<lc_gram_t<true, false, true>>(input_file, str_queries);
         }
     }else{
         if(has_rl_rules){
-            lc_gram_t<false, true, true> gram;
-            load_from_file(input_file, gram);
-            for(auto const& query : query_coords){
-                std::string dc_output;
-                gram.im_str_rand_access(query.str, query.start, query.end, dc_output);
-                std::cout<<query.str<<":"<<query.start<<"-"<<query.end<<std::endl;
-                std::cout<<dc_output<<std::endl;
-            }
+            access_with_gram<lc_gram_t<false, true, true>>(input_file, str_queries);
         }else{
-            lc_gram_t<false, false, true> gram;
-            load_from_file(input_file, gram);
-            for(auto const& query : query_coords){
-                std::string dc_output;
-                gram.im_str_rand_access(query.str, query.start, query.end, dc_output);
-                std::cout<<query.str<<":"<<query.start<<"-"<<query.end<<std::endl;
-                std::cout<<dc_output<<std::endl;
-            }
+            access_with_gram<lc_gram_t<false, false, true>>(input_file, str_queries);
         }
     }
 }
 
 
-std::vector<str_coord_type> parse_query_coords(std::vector<std::string>& str_queries){
+std::vector<str_coord_type> parse_query_coords(std::vector<std::string>& str_queries,
+                                               const std::vector<std::string>& seq_names){
+
+    // Build name-to-index map if we have sequence names
+    std::unordered_map<std::string, size_t> name_map;
+    for (size_t i = 0; i < seq_names.size(); i++) {
+        name_map[seq_names[i]] = i;
+    }
 
     size_t str;
     off_t start, end;
@@ -211,41 +264,57 @@ std::vector<str_coord_type> parse_query_coords(std::vector<std::string>& str_que
     for(auto const &coord: str_queries){
         std::vector<std::string> tmp = split(coord, ':');
         if(tmp.size()!=2){
-            std::cout<<"Coordinate error: query \""<<coord<<"\" is il-formed"<<std::endl;
+            std::cout<<"Coordinate error: query \""<<coord<<"\" is ill-formed"<<std::endl;
             exit(1);
         }
         std::vector<std::string> tmp2 = split(tmp[1], '-');
         if(tmp2.size()!=2){
-            std::cout<<"Coordinate error: query \""<<coord<<"\" is il-formed"<<std::endl;
+            std::cout<<"Coordinate error: query \""<<coord<<"\" is ill-formed"<<std::endl;
             exit(1);
         }
 
+        // Try numeric parse first; if it fails, look up as sequence name
         try{
             str = stoi(tmp[0]);
-        } catch (const std::invalid_argument & e) {
-            std::cout << "Coordinate error: \""<<tmp[0] <<"\" in \""<<coord<<"\" is not a valid string ID\n";
-            exit(1);
-        } catch (const std::out_of_range & e) {
+        } catch (const std::invalid_argument &) {
+            // Not a number — try name lookup
+            auto it = name_map.find(tmp[0]);
+            if (it != name_map.end()) {
+                str = it->second;
+            } else {
+                std::cout << "Coordinate error: sequence name \"" << tmp[0]
+                          << "\" not found in grammar" << std::endl;
+                if (!seq_names.empty()) {
+                    std::cout << "  Available sequences:";
+                    for (size_t i = 0; i < std::min(seq_names.size(), (size_t)10); i++) {
+                        std::cout << " " << seq_names[i];
+                    }
+                    if (seq_names.size() > 10) std::cout << " ... (" << seq_names.size() << " total)";
+                    std::cout << std::endl;
+                }
+                exit(1);
+            }
+        } catch (const std::out_of_range &) {
             std::cout << "Coordinate error: \""<<tmp[0] <<"\" in \""<<coord<<"\" is not a valid string ID\n";
             exit(1);
         }
 
         try{
             start = stoi(tmp2[0]);
-        } catch (const std::invalid_argument & e) {
+        } catch (const std::invalid_argument &) {
             std::cout << "Coordinate error: \""<<tmp2[0] <<"\" in \""<<coord<<"\" is not a valid start\n";
             exit(1);
-        } catch (const std::out_of_range & e) {
+        } catch (const std::out_of_range &) {
             std::cout << "Coordinate error: \""<<tmp2[0] <<"\" in \""<<coord<<"\" is not a valid start\n";
             exit(1);
         }
 
         try{
             end = stoi(tmp2[1]);
-        } catch (const std::invalid_argument & e) {
+        } catch (const std::invalid_argument &) {
             std::cout << "Coordinate error: \""<<tmp2[1] <<"\" in \""<<coord<<"\" is not a valid end\n";
             exit(1);
-        } catch (const std::out_of_range & e) {
+        } catch (const std::out_of_range &) {
             std::cout << "Coordinate error: \""<<tmp2[1] <<"\" in \""<<coord<<"\" is not a valid end\n";
             exit(1);
         }
@@ -268,18 +337,26 @@ int main(int argc, char** argv) {
     }
 
     if(app.got_subcommand("cmp")) {
-        std::cout << "\nInput file: " << args.input_file << " ("<<report_space(input_file_size(args.input_file))<<")"<<std::endl;
-        if (args.output_file.empty()) args.output_file = std::filesystem::path(args.input_file).filename();
-        args.output_file = std::filesystem::path(args.output_file).replace_extension(".lcg");
-        std::string input_collection = args.input_file;
-        comp_int(input_collection, args);
+        if (!args.fasta_list.empty()) {
+            // FASTA file list mode
+            comp_fasta_int(args);
+        } else if (!args.input_file.empty()) {
+            // Plain text mode
+            std::cout << "\nInput file: " << args.input_file << " ("<<report_space(input_file_size(args.input_file))<<")"<<std::endl;
+            if (args.output_file.empty()) args.output_file = std::filesystem::path(args.input_file).filename();
+            args.output_file = std::filesystem::path(args.output_file).replace_extension(".lcg");
+            std::string input_collection = args.input_file;
+            comp_int(input_collection, args);
+        } else {
+            std::cerr << "Error: either TEXT or -l/--fasta-list is required" << std::endl;
+            exit(1);
+        }
     } else if(app.got_subcommand("met")){
         print_metadata(args.input_file);
     } else if (app.got_subcommand("acc")){
-        std::vector<str_coord_type> query_coords = parse_query_coords(args.ra_positions);
         bool has_rl_rules, has_cg_rules, has_rand_access;
         std::tie(has_rl_rules, has_cg_rules, has_rand_access) = read_grammar_flags(args.input_file);
-        access_int(args.input_file, query_coords, has_rl_rules, has_cg_rules, has_rand_access);
+        access_int(args.input_file, args.ra_positions, has_rl_rules, has_cg_rules, has_rand_access);
     } else {
         std::cout<<" Unknown command "<<std::endl;
         return 1;

--- a/main.cpp
+++ b/main.cpp
@@ -1,6 +1,7 @@
 #include "external/CLI11.hpp"
 #include "merge_grams.h"
 #include "grammar_algorithms.h"
+#include "build_gram/input_reader.h"
 
 struct arguments{
     std::string input_file;
@@ -267,7 +268,7 @@ int main(int argc, char** argv) {
     }
 
     if(app.got_subcommand("cmp")) {
-        std::cout << "\nInput file: " << args.input_file << " ("<<report_space(file_size(args.input_file))<<")"<<std::endl;
+        std::cout << "\nInput file: " << args.input_file << " ("<<report_space(input_file_size(args.input_file))<<")"<<std::endl;
         if (args.output_file.empty()) args.output_file = std::filesystem::path(args.input_file).filename();
         args.output_file = std::filesystem::path(args.output_file).replace_extension(".lcg");
         std::string input_collection = args.input_file;


### PR DESCRIPTION
## Summary
- **Native BGZF (bgzip) input support**: LCG can now directly read `.fa.gz` BGZF-compressed FASTA files without external decompression, using htslib
- **FASTA file list mode** (`-l`/`--fasta-list`): Accepts a text file listing FASTA paths (one per line), streams through them sequentially to build a single grammar — supports both plain and BGZF-compressed files
- **Named-sequence random access**: The `acc` subcommand now accepts `seqname:start-end` coordinates in addition to numeric indices
- **Colon-in-name fix**: Correctly parses sequence names containing colons (e.g. `gi|528476637:31323556-31326919`) by splitting on the last colon

## Details
- htslib dependency added to CMakeLists.txt (via pkg-config or `HTSLIB_ROOT`)
- New `fasta_reader` class streams FASTA data with bounded 8MB buffer
- New `input_reader` abstraction with `plain_reader` and `bgzf_reader` backends
- Sequence name → index mapping stored in grammar metadata for named access

## Test plan
- [x] Tested with S. cerevisiae 8-strain pangenome (136 seqs, BGZF) + human sequences (9 seqs, plain FASTA)
- [x] 50 random-range access checks pass byte-for-byte (see PR #2 for CI)